### PR TITLE
refactor: 상세페이지의 생성자 인자 변경

### DIFF
--- a/lib/food_detail_page.dart
+++ b/lib/food_detail_page.dart
@@ -1,15 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class FoodDetailPage extends StatefulWidget {
   final Map<String, String> food;
   final List<Map<String, dynamic>?> foods;
-  final void Function(Map<String, String> food) onAddToCart;
 
-  const FoodDetailPage(
-      {Key? key,
-      required this.food,
-      required this.foods,
-      required this.onAddToCart})
+  const FoodDetailPage({Key? key, required this.food, required this.foods})
       : super(key: key);
 
   @override
@@ -70,7 +66,7 @@ class _FoodDetailPageState extends State<FoodDetailPage> {
                   widget.food['amount'] = sum.toString();
                 } else {
                   widget.food['amount'] = _quantity.toString();
-                  widget.onAddToCart(widget.food);
+                  widget.foods.add(widget.food);
                 }
               },
             ),
@@ -92,7 +88,8 @@ class _FoodDetailPageState extends State<FoodDetailPage> {
                 child: Image.asset(widget.food['image']!, fit: BoxFit.cover)),
             SizedBox(height: 30),
             Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-              Text("상품 가격 : ${(widget.food['price']!)}원",
+              Text(
+                  "상품 가격 : ${NumberFormat('#,###').format(int.parse(widget.food['price']!))}원",
                   style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
               SizedBox(width: 8)
             ]),
@@ -147,7 +144,7 @@ class _FoodDetailPageState extends State<FoodDetailPage> {
                       Text('총 가격',
                           style: TextStyle(fontSize: 14, color: Colors.black)),
                       Text(
-                        '${(totalPrice)}원',
+                        '${NumberFormat('#,###').format(totalPrice)}원',
                         style: TextStyle(
                             fontSize: 16, fontWeight: FontWeight.bold),
                       ),

--- a/lib/food_list_page.dart
+++ b/lib/food_list_page.dart
@@ -28,15 +28,8 @@ class _FoodListPageState extends State<FoodListPage> {
     },
   ];
 
-  // 현진, 장바구니 페이지를 위해 만든 변수
+  // 상세페이지, 장바구니 페이지를 위해 만든 변수
   List<Map<String, dynamic>?> cartList = [];
-
-  // 현진, 장바구니 페이지를 위해 만든 상태 업데이트 함수
-  void onAddToCart(food) {
-    setState(() {
-      cartList.add(food);
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -84,9 +77,9 @@ class _FoodListPageState extends State<FoodListPage> {
                             context,
                             MaterialPageRoute(
                               builder: (context) => FoodDetailPage(
-                                  food: food,
-                                  foods: cartList,
-                                  onAddToCart: onAddToCart),
+                                food: food,
+                                foods: cartList,
+                              ),
                             ),
                           );
                         },


### PR DESCRIPTION
목록 페이지에서 넘겨 받은 setState메서드를 제거함
객체는 참조이므로 없어도 문제 없음